### PR TITLE
Cleanup Tabs component

### DIFF
--- a/components/ui/tabs.tsx
+++ b/components/ui/tabs.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { useOptimistic, useTransition } from 'react';
+import { startTransition, useOptimistic } from 'react';
 import { Skeleton } from '@/components/ui/skeleton';
 import { cn } from '@/lib/utils';
 import type { Route } from 'next';
@@ -11,19 +11,18 @@ type Tab<T extends string> = { label: string; value: T; href: Route };
 type Props<T extends string> = {
   tabs: Tab<T>[];
   active: T;
+  action: (value: T) => void | Promise<void>;
   label?: string;
 };
 
-export function Tabs<T extends string>({ tabs, active, label = 'Sections' }: Props<T>) {
+export function Tabs<T extends string>({ tabs, active, action, label = 'Sections' }: Props<T>) {
   const [optimisticActive, setOptimisticActive] = useOptimistic(active);
-  const [isPending, startTransition] = useTransition();
 
   return (
     <nav
       className="border-divider/70 dark:border-divider-dark/70 flex border-b text-sm"
       aria-label={label}
       data-client="Tabs"
-      data-pending={isPending ? '' : undefined}
     >
       {tabs.map(t => {
         const isActive = optimisticActive === t.value;
@@ -33,8 +32,9 @@ export function Tabs<T extends string>({ tabs, active, label = 'Sections' }: Pro
             href={t.href}
             onNavigate={() => {
               if (t.value === optimisticActive) return;
-              startTransition(() => {
+              startTransition(async () => {
                 setOptimisticActive(t.value);
+                await action(t.value);
               });
             }}
             aria-current={isActive ? 'page' : undefined}

--- a/components/ui/tabs.tsx
+++ b/components/ui/tabs.tsx
@@ -1,42 +1,40 @@
 'use client';
 
 import Link from 'next/link';
-import { startTransition, useOptimistic } from 'react';
+import { useOptimistic, useTransition } from 'react';
 import { Skeleton } from '@/components/ui/skeleton';
 import { cn } from '@/lib/utils';
 import type { Route } from 'next';
 
-type Tab<T extends string> = { label: string; value: T };
+type Tab<T extends string> = { label: string; value: T; href: Route };
 
 type Props<T extends string> = {
   tabs: Tab<T>[];
   active: T;
-  action: (value: T) => void | Promise<void>;
-  href: (value: T) => Route;
   label?: string;
 };
 
-export function Tabs<T extends string>({ tabs, active, action, href, label = 'Sections' }: Props<T>) {
+export function Tabs<T extends string>({ tabs, active, label = 'Sections' }: Props<T>) {
   const [optimisticActive, setOptimisticActive] = useOptimistic(active);
+  const [isPending, startTransition] = useTransition();
 
   return (
     <nav
       className="border-divider/70 dark:border-divider-dark/70 flex border-b text-sm"
       aria-label={label}
       data-client="Tabs"
+      data-pending={isPending ? '' : undefined}
     >
       {tabs.map(t => {
         const isActive = optimisticActive === t.value;
         return (
           <Link
             key={t.value}
-            href={href(t.value)}
-            onClick={e => {
-              e.preventDefault();
+            href={t.href}
+            onNavigate={() => {
               if (t.value === optimisticActive) return;
-              startTransition(async () => {
+              startTransition(() => {
                 setOptimisticActive(t.value);
-                await action(t.value);
               });
             }}
             aria-current={isActive ? 'page' : undefined}

--- a/features/drop/components/feed-tabs.tsx
+++ b/features/drop/components/feed-tabs.tsx
@@ -1,15 +1,14 @@
 'use client';
 
-import { useRouter, useSearchParams } from 'next/navigation';
-import { useTransition } from 'react';
+import { useSearchParams } from 'next/navigation';
 import { Tabs } from '@/components/ui/tabs';
 import type { Route } from 'next';
 
 type FeedTab = 'following' | 'discover';
 
-const FEED_TABS: { label: string; value: FeedTab }[] = [
-  { label: 'Following', value: 'following' },
-  { label: 'Discover', value: 'discover' },
+const FEED_TABS: { label: string; value: FeedTab; href: Route }[] = [
+  { label: 'Following', value: 'following', href: '/' as Route },
+  { label: 'Discover', value: 'discover', href: '/?tab=discover' as Route },
 ];
 
 function parseTab(value: string | null): FeedTab {
@@ -17,24 +16,12 @@ function parseTab(value: string | null): FeedTab {
 }
 
 export function FeedTabs() {
-  const router = useRouter();
   const searchParams = useSearchParams();
   const active = parseTab(searchParams.get('tab'));
-  const [isPending, startTransition] = useTransition();
 
   return (
-    <div data-pending={isPending ? '' : undefined}>
-      <Tabs
-        tabs={FEED_TABS}
-        active={active}
-        action={value => {
-          startTransition(() => {
-            router.push((value === 'following' ? '/' : '/?tab=discover') as Route);
-          });
-        }}
-        href={value => (value === 'following' ? '/' : '/?tab=discover') as Route}
-        label="Feed sections"
-      />
+    <div>
+      <Tabs tabs={FEED_TABS} active={active} label="Feed sections" />
     </div>
   );
 }

--- a/features/drop/components/feed-tabs.tsx
+++ b/features/drop/components/feed-tabs.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useSearchParams } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useTransition } from 'react';
 import { Tabs } from '@/components/ui/tabs';
 import type { Route } from 'next';
 
@@ -16,12 +17,23 @@ function parseTab(value: string | null): FeedTab {
 }
 
 export function FeedTabs() {
+  const router = useRouter();
   const searchParams = useSearchParams();
   const active = parseTab(searchParams.get('tab'));
+  const [isPending, startTransition] = useTransition();
 
   return (
-    <div>
-      <Tabs tabs={FEED_TABS} active={active} label="Feed sections" />
+    <div data-pending={isPending ? '' : undefined}>
+      <Tabs
+        tabs={FEED_TABS}
+        active={active}
+        action={value => {
+          startTransition(() => {
+            router.push((value === 'following' ? '/' : '/?tab=discover') as Route);
+          });
+        }}
+        label="Feed sections"
+      />
     </div>
   );
 }

--- a/features/user/components/profile-tabs.tsx
+++ b/features/user/components/profile-tabs.tsx
@@ -1,19 +1,33 @@
 'use client';
 
+import { useRouter } from 'next/navigation';
+import { useTransition } from 'react';
 import { Tabs } from '@/components/ui/tabs';
 import type { Route } from 'next';
 
 export type ProfileTab = 'drops' | 'replies';
 
 export function ProfileTabs({ handle, active }: { handle: string; active: ProfileTab }) {
-  const PROFILE_TABS: { label: string; value: ProfileTab; href: Route }[] = [
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+
+  const tabs: { label: string; value: ProfileTab; href: Route }[] = [
     { label: 'Drops', value: 'drops', href: `/u/${handle}` as Route },
     { label: 'Replies', value: 'replies', href: `/u/${handle}?tab=replies` as Route },
   ];
 
   return (
-    <div>
-      <Tabs tabs={PROFILE_TABS} active={active} label="Profile sections" />
+    <div data-pending={isPending ? '' : undefined}>
+      <Tabs
+        tabs={tabs}
+        active={active}
+        action={value => {
+          startTransition(() => {
+            router.push(`/u/${handle}${value === 'drops' ? '' : `?tab=${value}`}` as Route);
+          });
+        }}
+        label="Profile sections"
+      />
     </div>
   );
 }

--- a/features/user/components/profile-tabs.tsx
+++ b/features/user/components/profile-tabs.tsx
@@ -1,34 +1,19 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
-import { useTransition } from 'react';
 import { Tabs } from '@/components/ui/tabs';
 import type { Route } from 'next';
 
 export type ProfileTab = 'drops' | 'replies';
 
-const PROFILE_TABS: { label: string; value: ProfileTab }[] = [
-  { label: 'Drops', value: 'drops' },
-  { label: 'Replies', value: 'replies' },
-];
-
 export function ProfileTabs({ handle, active }: { handle: string; active: ProfileTab }) {
-  const router = useRouter();
-  const [isPending, startTransition] = useTransition();
+  const PROFILE_TABS: { label: string; value: ProfileTab; href: Route }[] = [
+    { label: 'Drops', value: 'drops', href: `/u/${handle}` as Route },
+    { label: 'Replies', value: 'replies', href: `/u/${handle}?tab=replies` as Route },
+  ];
 
   return (
-    <div data-pending={isPending ? '' : undefined}>
-      <Tabs
-        tabs={PROFILE_TABS}
-        active={active}
-        action={value => {
-          startTransition(() => {
-            router.push(`/u/${handle}${value === 'drops' ? '' : `?tab=${value}`}` as Route);
-          });
-        }}
-        href={value => `/u/${handle}${value === 'drops' ? '' : `?tab=${value}`}` as Route}
-        label="Profile sections"
-      />
+    <div>
+      <Tabs tabs={PROFILE_TABS} active={active} label="Profile sections" />
     </div>
   );
 }


### PR DESCRIPTION
Follow-up to https://github.com/aurorascharff/next16-social-media/commit/c18ad0ab5c751a35ec4c04016af08c4c7bc80705.  Refactors the Tab component to:
- use `onNavigate` instead of `onClick` (fixing `Ctrl`/`Cmd` + Click behavior)
- obviate `action` and `href` props