### PR TITLE
Clarify search param input sync hook

### DIFF
--- a/features/search/components/search.tsx
+++ b/features/search/components/search.tsx
@@ -7,7 +7,7 @@ import { Boundary } from '@/components/internal/boundary';
 import { SeedFromSearchParam } from '@/components/scripts/seed-from-search-param';
 import { Section } from '@/components/ui/section';
 
-import { useSyncInputToSearchParam } from '@/hooks/use-sync-input-to-search-param';
+import { useSyncSearchParamToInput } from '@/hooks/use-sync-search-param-to-input';
 import type { Route } from 'next';
 
 const inputClass = 'bg-card dark:bg-card-dark placeholder-gray w-full rounded-lg py-2.5 pr-3 pl-9 text-sm outline-none';
@@ -18,7 +18,7 @@ export function Search({ children }: { children: React.ReactNode }) {
   const inputId = useId();
   const [isPending, startTransition] = useTransition();
 
-  useSyncInputToSearchParam(inputRef, 'q');
+  useSyncSearchParamToInput(inputRef, 'q');
 
   return (
     <Boundary label="Search">

--- a/hooks/use-sync-search-param-to-input.ts
+++ b/hooks/use-sync-search-param-to-input.ts
@@ -3,11 +3,11 @@
 import { useLayoutEffect, type RefObject } from 'react';
 
 /**
- * Sync an uncontrolled input to a URL search param on mount, before paint.
+ * Sync an uncontrolled input from a URL search param on mount, before paint.
  * Needed on soft navigations because Activity can preserve a stale DOM value
  * that no longer matches the URL.
  */
-export function useSyncInputToSearchParam(ref: RefObject<HTMLInputElement | null>, param: string) {
+export function useSyncSearchParamToInput(ref: RefObject<HTMLInputElement | null>, param: string) {
   useLayoutEffect(() => {
     const el = ref.current;
     if (!el) return;


### PR DESCRIPTION
## Summary

- Rename `useSyncInputToSearchParam` to `useSyncSearchParamToInput`
- Update the hook comment to describe the actual sync direction
- Update the search component import/callsite

## Why

The hook reads the current URL search param and writes it into an uncontrolled input before paint. The previous name and comment suggested the opposite direction, which made the behavior confusing when reading the code.

Fixes #8.

## Validation

- `pnpm lint` passes with 0 errors; existing warnings remain in generated Prisma files and `prisma/seed.ts`.