### PR TITLE
Rename runtime prefetching to optimizing prefetching

### DIFF
--- a/.agents/skills/nextjs-app-architecture/references/pages-suspense.md
+++ b/.agents/skills/nextjs-app-architecture/references/pages-suspense.md
@@ -197,11 +197,11 @@ Fixes:
 
 To audit CLS, use React DevTools' Suspense panel to pin each boundary in its loading state and check vertical positions.
 
-## Runtime prefetch for high-value routes
+## Optimizing prefetching for high-value routes
 
 With `cacheComponents` + [`partialPrefetching`](https://preview.nextjs.org/docs/app/api-reference/config/next-config-js/partialPrefetching) enabled, a visible `<Link>` prefetches the destination's shared [App Shell](https://preview.nextjs.org/docs/app/glossary#app-shell) — enough to commit navigation instantly, with link-specific content streaming after. The default (`'auto'`) already does this; don't write `prefetch = 'auto'`.
 
-Use `<Link prefetch={true}>` on high-value links to also resolve the destination's per-link runtime data (`params`, `searchParams`, the full URL) before the click. Each such link can wake the server for a runtime prerender, so reserve it for routes users predictably visit next. See [runtime prefetching](https://preview.nextjs.org/docs/app/guides/runtime-prefetching).
+Use `<Link prefetch={true}>` on high-value links to also resolve the destination's per-link data (`params`, `searchParams`, the full URL) at prefetch time. Each such link can wake the server for a prerender, so reserve it for routes users predictably visit next. See [Optimizing prefetching](https://preview.nextjs.org/docs/app/guides/optimizing-prefetching).
 
 Can't enable `partialPrefetching` app-wide yet? Opt in per route with `export const prefetch = 'partial'` on the destination, then drop the per-route exports once the global flag is on — see [Adopting Partial Prefetching](https://preview.nextjs.org/docs/app/guides/adopting-partial-prefetching) for the incremental path and [prefetch config](https://preview.nextjs.org/docs/app/api-reference/file-conventions/route-segment-config/prefetch) for the options. To validate navigation feels instant, see the [`instant` config](https://preview.nextjs.org/docs/app/api-reference/file-conventions/route-segment-config/instant) and [Instant Navigation guide](https://preview.nextjs.org/docs/app/guides/instant-navigation).
 

--- a/components/ui/hover-prefetch-link.tsx
+++ b/components/ui/hover-prefetch-link.tsx
@@ -9,9 +9,9 @@ type Props<T extends string = string> = Omit<React.ComponentProps<typeof Link>, 
   href: Route<T> | URL;
 };
 
-// A `<Link>` that defers its runtime prefetch until the user shows intent.
+// A `<Link>` that defers its prefetch until the user shows intent.
 // Until hover/focus it sits at the App Shell (`prefetch={null}`); intent upgrades
-// it to a full runtime prefetch so the click lands on warm content. Use for
+// it to a full prefetch so the click lands on warm content. Use for
 // low-intent list links (tags) so N of them don't each wake a server on render.
 export function HoverPrefetchLink<T extends string>({ href, onMouseEnter, onFocus, ...props }: Props<T>) {
   const [intent, setIntent] = useState(false);

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -170,7 +170,7 @@ const DROPS: SeedDrop[] = [
   },
   {
     authorHandle: 'aurora',
-    body: "Spent the day on how navigation feels. High-value links in Drop opt into runtime prefetch, so opening a drop or a profile is instant:\n\n```tsx\n<Link href={href} prefetch={true} />\n```\n\nBy the time you click, the next screen is already warm.",
+    body: "Spent the day on how navigation feels. High-value links in Drop resolve their data at prefetch time, so opening a drop or a profile is instant:\n\n```tsx\n<Link href={href} prefetch={true} />\n```\n\nBy the time you click, the next screen is already warm.",
     createdAt: new Date(now - 4 * hour),
     id: 'd7',
     likes: 1_540,
@@ -600,7 +600,7 @@ const REPLIES: SeedDrop[] = [
   },
   {
     authorHandle: 'halo',
-    body: 'Runtime prefetch on every route is the kind of thing you only notice when it is missing.',
+    body: 'Prefetching this aggressively is the kind of thing you only notice when it is missing.',
     createdAt: new Date(now - 9 * hour),
     id: 'r14',
     likes: 132,
@@ -611,7 +611,7 @@ const REPLIES: SeedDrop[] = [
   },
   {
     authorHandle: 'aurora',
-    body: 'Follow-up: the drop detail is runtime-prefetched, and the profile links only prefetch on hover so we do not prefetch the whole feed at once.',
+    body: 'Follow-up: the drop detail resolves at prefetch time, and the profile links only prefetch on hover so we do not prefetch the whole feed at once.',
     createdAt: new Date(now - 8 * hour),
     id: 'r15',
     likes: 264,

--- a/tests/home-page.spec.ts
+++ b/tests/home-page.spec.ts
@@ -11,7 +11,7 @@ test.describe('Home page (/)', () => {
     });
   });
 
-  test('client navigation shows the runtime-prefetched feed', async ({ page }) => {
+  test('client navigation shows the feed resolved at prefetch time', async ({ page }) => {
     await page.goto('/bookmarks');
     const link = page.locator('aside a[aria-label="Home"]').first();
     await link.waitFor({ state: 'visible', timeout: 15000 });

--- a/tests/profile-page.spec.ts
+++ b/tests/profile-page.spec.ts
@@ -12,7 +12,7 @@ test.describe('Profile page (/u/[handle])', () => {
     });
   });
 
-  test('client navigation shows the runtime-prefetched profile feed', async ({ page }) => {
+  test('client navigation shows the profile feed resolved at prefetch time', async ({ page }) => {
     await page.goto('/');
     const link = page.locator('aside a[aria-label="Profile"]').first();
     await link.waitFor({ state: 'visible', timeout: 15000 });

--- a/tests/search-page.spec.ts
+++ b/tests/search-page.spec.ts
@@ -2,8 +2,8 @@ import { instant } from '@next/playwright';
 import { test, expect } from '@playwright/test';
 
 test.describe('Search page (/search)', () => {
-  // (No runtime-prefetch reveal case here — unlike the feed pages, no link carries a `?q=`, and the empty
-  //  state is static, so there's no runtime-prefetched result set to assert.)
+  // (No prefetch-time reveal case here — unlike the feed pages, no link carries a `?q=`, and the empty
+  //  state is static, so there's no prefetch-time result set to assert.)
   test('initial page load shows the search shell without results', async ({ page }) => {
     await page.goto('/');
 


### PR DESCRIPTION
`/docs/app/guides/runtime-prefetching` now redirects to [`/docs/app/guides/optimizing-prefetching`](https://nextjs.org/docs/app/guides/optimizing-prefetching), and that guide no longer contains the phrase "runtime prefetch" anywhere. Its sections are "Resolve URL data at prefetch time", "Include session data in the shell", and "Extract and pass `use cache: private`".

- `.agents/skills/.../pages-suspense.md`: heading becomes `## Optimizing prefetching for high-value routes`, "per-link runtime data ... before the click" becomes "... at prefetch time", "a runtime prerender" becomes "a prerender", and the link points at the new slug.
- `components/ui/hover-prefetch-link.tsx`: comments no longer say "runtime prefetch".
- `tests/home-page.spec.ts`, `tests/profile-page.spec.ts`: test names now read "resolved at prefetch time" instead of "runtime-prefetched". `tests/search-page.spec.ts`: same in the explanatory comment.
- `prisma/seed.ts`: three seeded posts reworded off the old term.

Docs, comments, test names, and seed copy only. No assertions changed and this repo has no `prefetch = 'allow-runtime'` usage, so nothing behavioral is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)